### PR TITLE
CAM-11977 - fix(style): reset summary style in FireFox

### DIFF
--- a/styles/_content.less
+++ b/styles/_content.less
@@ -1,3 +1,8 @@
+
+summary {
+  display: revert;
+}
+
 blockquote {
   border-left-color: mix(@brand-primary, @gray-lighter);
 }


### PR DESCRIPTION
related to CAM-11977

Root cause:
Bootstrap sets summary to `display: block`, which is the standard (AFAIK).
Firefox sets it to `list-item` for some reason and won't display the marker otherwise.
`display: initial` would reset it to the standard (block), so we need to revert it to the style FF gave it.

Fun Fact: Chrome does not support `revert` as a attribute value :shrug: 