### PR TITLE
add HTML template file for opening links in new tab

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,0 +1,1 @@
+<a href="{{ .Destination | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}{{ if strings.HasPrefix .Destination "http" }} target="_blank"{{ end }}>{{ .Text }}</a>


### PR DESCRIPTION
When clicking a URL, the URL will open in a new tab. I confirmed this functionality with the URLs in Get Started > Quickstart content.

This HTML template appears to work for all links except links inside notes. 