### PR TITLE
docs(docs-banner): update career page link

### DIFF
--- a/layouts/partials/banner.html
+++ b/layouts/partials/banner.html
@@ -6,7 +6,7 @@
       We are looking for talented people.
     </p>
     <p>
-      Check out our <a href="http://camunda.com/about/jobs/">open positions</a>.
+      Check out our <a href="https://camunda.com/career/">open positions</a>.
     </p>
   </blockquote>
 </div>


### PR DESCRIPTION
I'm having a hard time tracking down all the career page links for the docs-banner element.
 
<img width="1344" alt="Screen Shot 2022-02-11 at 8 59 10 AM" src="https://user-images.githubusercontent.com/1051363/153618541-e05b7af7-a9c3-4592-a0e5-59f5e2a507b9.png">

This link doesn't work and routes to the wrong page, but when I updated the docs-banner the text wasn't the same so I'm wondering if there are other places this needs to be updated.

I apologize there is no corresponding issue or JIRA at this time, I thought this would be a quick fix 😅 