### PR TITLE
improve(setup): abstract grunt behind an npm task

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ git clone git@github.com:camunda/camunda-docs-theme.git
 # go into its directory
 cd camunda-docs-theme
 npm i
-grunt build
+npm run build
 ```
 
 _Note:_ you can clone this repository anywhere,
@@ -20,7 +20,7 @@ but you may then change the `setup.target` value of `package.json`.
 ## Working
 
 After installing (you probably want to have [hugo running as watching server][building-docs])
-and then use `grunt` in this directory.
+and then run `npm run build` from this directory.
 
 ## Consuming the theme
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ and then run `npm run build` from this directory.
 
 ## Consuming the theme
 
-The simplest way to consume the theme in a project is to use the git subtree facilitites:
+The simplest way to consume the theme in a project is to use the git subtree facilities:
 
 Adding the latest version of the theme as `camunda`:
 
@@ -54,6 +54,5 @@ guest OS.
 ## Licence
 
 [MIT](LICENSE)
-
 
 [building-docs]: https://github.com/camunda/camunda-docs-manual/#building-the-documentation

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "Styling for http://docs.camunda.org/.",
   "main": "index.js",
   "scripts": {
+    "build": "grunt build",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {


### PR DESCRIPTION
I noticed while getting this project running that the docs asked me to run `grunt build`, which suggested to me that people probably have grunt installed globally. To avoid version disparities, and to avoid having to install grunt globally, this PR: 

1. Adds an npm script named `build`, which calls `grunt build`. Note that `grunt` is already a dependency, so it will be installed during `npm install`. 
2. Updates the README setup instructions to suggest using `npm run build` instead of calling a global version of grunt. 

unrelated...
3. Corrects a spelling error.