### PR TITLE
fix(seo): wrap sidebar navigation in a semantic `nav` element instead of `div`

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -94,9 +94,9 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 <div class="search-underlay"></div>
 
-<div class="site-menu">
+<nav class="site-menu">
   {{ partialCached "menu.html" . }}
-</div>
+</nav>
 
 
 <div class="page-wrapper">


### PR DESCRIPTION
This PR updates the sidebar navigation to be a `nav` element at the top level, instead of a `div`, with the intention of signaling to crawlers that it is not page content. 

## Why? 

This image shows the top 10 search results for the term "database schema". Over half the results appear to have been matched due to the "Database Schema" item in the side navigation.

![image](https://user-images.githubusercontent.com/1627089/176767990-59ebdd89-c81b-445a-a367-3b06e03a9c6b.png)

This suggests that Google is including our sidebar navigation as content on the page. I can't guarantee that converting the parent element of the sidebar from a `div` to a `nav` will remove these false matches, but it seems reasonable to assume that crawlers would treat `nav` elements as non-unique content on the page, and ignore their contents.  

## Follow-up work

- Apply this update to the camunda-docs-manual repo
- Figure out if/how we can request a crawl of the docs from Google.