### PR TITLE
feat: add a rel=canonical link to every page

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -34,6 +34,7 @@
   {{ $styles := resources.Get "css/docs.css" | fingerprint }}
 
   <link rel="stylesheet" href="{{ $styles.Permalink }}" integrity="{{ $styles.Data.Integrity }}">
+  <link rel="canonical" href="{{ .Permalink | replaceRE `(https:\/\/([^\/]*)\/manual\/)([^\/]*\/)(.*)` `$1$4` }}" />
 </head>
 <body class="{{ .Params.bodyclass }}">
 


### PR DESCRIPTION
Partially addresses https://github.com/camunda/product-hub/issues/232.

Adds a rel=canonical link to each page, pointing to the corresponding versionless URL. The docs are set up so that versionless URLs redirect to the current version, so crawlers should always use the current version for their suggested search results (theoretically).

Following this work, I'll be integrating this change into all published branches of https://github.com/camunda/camunda-docs-manual. 

## Proof that the regular expression does what we want it to do

Each of the blue highlighted lines matches the regular expression; the bottom "Substitution" shows each corresponding canonical URL. 

<img width="1021" alt="image" src="https://user-images.githubusercontent.com/1627089/200367721-1a919111-df4e-4111-b778-94a3045cbd63.png">

