### PR TITLE
feat (SEO): only use absolute URLs in sitemap and `link rel=canonical`

### DIFF
--- a/layouts/_default/sitemap.xml
+++ b/layouts/_default/sitemap.xml
@@ -5,9 +5,7 @@
   <url>
     {{- $permalink := .Permalink }}
     {{- if ($.Site.Params.section.versions) }}
-      {{- if (eq (index $.Site.Params.section.versions 1) $.Site.Params.section.version) }}
-        {{- $permalink = $permalink | replaceRE `(\/manual\/)([^\/]*\/)(.*)` `$1$3` }}
-      {{- end }}
+      {{- $permalink = $permalink | replaceRE `(\/manual\/)([^\/]*\/)(.*)` `$1$3` }}
     {{- end }}
     <loc>{{ $.Site.Params.canonicalBasePath }}{{ $permalink }}</loc>{{ if not .Lastmod.IsZero }}
     <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}

--- a/layouts/_default/sitemap.xml
+++ b/layouts/_default/sitemap.xml
@@ -1,4 +1,4 @@
-{{/* This template is overridden to emit a versionless permalink for the most recent version. This allows us to submit the sitemap to crawlers with true canonical URLs. */}}
+{{/* This template is overridden to emit permalinks that (1) are absolute, and (2) do not include a version. This allows us to submit the sitemap to crawlers with true canonical URLs. */}}
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
   {{ range .Data.Pages }}
@@ -6,22 +6,22 @@
     {{- $permalink := .Permalink }}
     {{- if ($.Site.Params.section.versions) }}
       {{- if (eq (index $.Site.Params.section.versions 1) $.Site.Params.section.version) }}
-        {{- $permalink = .Permalink | replaceRE `(http[s]*:\/\/([^\/]*)\/manual\/)([^\/]*\/)(.*)` `$1$4` }}
+        {{- $permalink = $permalink | replaceRE `(\/manual\/)([^\/]*\/)(.*)` `$1$3` }}
       {{- end }}
     {{- end }}
-    <loc>{{ $permalink }}</loc>{{ if not .Lastmod.IsZero }}
+    <loc>{{ $.Site.Params.canonicalBasePath }}{{ $permalink }}</loc>{{ if not .Lastmod.IsZero }}
     <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
     <changefreq>{{ . }}</changefreq>{{ end }}{{ if ge .Sitemap.Priority 0.0 }}
     <priority>{{ .Sitemap.Priority }}</priority>{{ end }}{{ if .IsTranslated }}{{ range .Translations }}
     <xhtml:link
                 rel="alternate"
                 hreflang="{{ .Lang }}"
-                href="{{ .Permalink }}"
+                href="{{ $.Site.Params.canonicalBasePath }}{{ .Permalink }}"
                 />{{ end }}
     <xhtml:link
                 rel="alternate"
                 hreflang="{{ .Lang }}"
-                href="{{ .Permalink }}"
+                href="{{ $.Site.Params.canonicalBasePath }}{{ .Permalink }}"
                 />{{ end }}
   </url>
   {{ end }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -34,7 +34,7 @@
   {{ $styles := resources.Get "css/docs.css" | fingerprint }}
 
   <link rel="stylesheet" href="{{ $styles.Permalink }}" integrity="{{ $styles.Data.Integrity }}">
-  <link rel="canonical" href="{{ .Permalink | replaceRE `(http[s]*:\/\/([^\/]*)\/manual\/)([^\/]*\/)(.*)` `$1$4` }}" />
+  <link rel="canonical" href="{{ $.Site.Params.canonicalBasePath }}{{ .Permalink | replaceRE `(\/manual\/)([^\/]*\/)(.*)` `$1$3` }}" />
 </head>
 <body class="{{ .Params.bodyclass }}">
 


### PR DESCRIPTION
Part of https://github.com/camunda/product-hub/issues/232

In #31 I introduced a heavy-handed change, which assumed that all consumers of the theme would set their `baseURL` to an absolute URL. This resulted in CORS issues in the staging environment, because `baseURL` is used in more places than the sitemap and `link rel=canonical`. 

This PR takes the approach of being least invasive -- applying the absolute URL to the only two locations that I am interested in applying it to. 

This is done by introducing a new configuration variable, `canonicalBasePath`. If the theme consumer has this variable defined, it is pre-pended to the URL to make it truly canonical. If the theme consumer does not have this variable defined, there is no default value pre-pended. 

## Record of decisions

1. In previous iterations, I applied the removal of versions in canonical URLs to only the current version (i.e. 7.18). This felt unnecessary, so in this PR I'm now applying the removal of version _regardless_ of the version being built. I think this makes more sense, because the current version should always be the canonical for any document, no matter how old it is.
2. I opted to make the canonicalBasePath a configuration variable instead of hardcoding it, just in case there is a consumer of the theme that needs to override it.

## What the canonical URLs would look like for a numbered version that has canonicalBasePath defined

In this example, I built the 7.18 version with a canonicalBasePath of `https://docs.camunda.org`.

Sitemap:

<img width="764" alt="image" src="https://user-images.githubusercontent.com/1627089/201226434-13b6c0ad-8167-484d-9e92-86017aed2c5e.png">

`link rel=canonical` on a page:

<img width="808" alt="image" src="https://user-images.githubusercontent.com/1627089/201226470-20f482c1-871c-4e26-ab65-bd5e0b55beab.png">

## What the canonical URLs would look like for a version like `latest` that has canonicalBasePath defined

In this example, I built the 7.18 version with a canonicalBasePath of `https://docs.camunda.org`.

Sitemap:

<img width="756" alt="image" src="https://user-images.githubusercontent.com/1627089/201226945-4c8b2d22-8ace-4528-a6d0-d621c0874f59.png">

`link rel=canonical` on a page:

<img width="852" alt="image" src="https://user-images.githubusercontent.com/1627089/201226963-fedb5c2d-8e96-4d0d-bb51-695cb36b9a5a.png">

## What the canonical URLs would look like for a version that **does not** have canonicalBasePath defined

In this example, I built the master/develop version with no canonicalBasePath defined.

Sitemap:

<img width="675" alt="image" src="https://user-images.githubusercontent.com/1627089/201227086-c6dc3209-163a-4fec-8646-62f5a32fa6fb.png">

`link rel=canonical` on a page:

<img width="648" alt="image" src="https://user-images.githubusercontent.com/1627089/201227105-c0c75baf-a895-4746-9231-2429be82b665.png">

## Next steps

* Apply this change to v7.18
* Apply this change to master
* Apply this change to latest
* Apply this change to any older versions we decide are necessary.