### PR TITLE
feat: use versioned canonicals

### DIFF
--- a/layouts/_default/sitemap.xml
+++ b/layouts/_default/sitemap.xml
@@ -1,11 +1,13 @@
-{{/* This template is overridden to emit permalinks that (1) are absolute, and (2) do not include a version. This allows us to submit the sitemap to crawlers with true canonical URLs. */}}
+{{/* This template is overridden to emit permalinks that (1) are absolute, and (2) specify the most recent version. This allows us to submit the sitemap to crawlers with true canonical URLs. */}}
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
   {{ range .Data.Pages }}
   <url>
     {{- $permalink := .Permalink }}
     {{- if ($.Site.Params.section.versions) }}
-      {{- $permalink = $permalink | replaceRE `(\/manual\/)([^\/]*\/)(.*)` `$1$3` }}
+      {{- $latestVersion := (index $.Site.Params.section.versions 1) }}
+      {{- $replacementPattern := print "${1}" $latestVersion "/${3}" }}
+      {{- $permalink = $permalink | replaceRE `(\/manual\/)([^\/]*\/)(.*)` $replacementPattern }}
     {{- end }}
     <loc>{{ $.Site.Params.canonicalBasePath }}{{ $permalink }}</loc>{{ if not .Lastmod.IsZero }}
     <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -34,7 +34,13 @@
   {{ $styles := resources.Get "css/docs.css" | fingerprint }}
 
   <link rel="stylesheet" href="{{ $styles.Permalink }}" integrity="{{ $styles.Data.Integrity }}">
-  <link rel="canonical" href="{{ $.Site.Params.canonicalBasePath }}{{ .Permalink | replaceRE `(\/manual\/)([^\/]*\/)(.*)` `$1$3` }}" />
+  {{- $permalink := .Permalink }}
+  {{- if ($.Site.Params.section.versions) }}
+    {{- $latestVersion := (index $.Site.Params.section.versions 1) }}
+    {{- $replacementPattern := print "${1}" $latestVersion "/${3}" }}
+    {{- $permalink = $permalink | replaceRE `(\/manual\/)([^\/]*\/)(.*)` $replacementPattern }}
+  {{- end }}
+  <link rel="canonical" href="{{ $.Site.Params.canonicalBasePath }}{{ $permalink }}" />
 </head>
 <body class="{{ .Params.bodyclass }}">
 


### PR DESCRIPTION
Part of https://github.com/camunda/product-hub/issues/232.

Applies a new canonical strategy: use the latest numbered version for the canonical URL, both in the sitemap and in the individual page's `head` element.

This relies on older versions defining the latest version in their config. That isn't currently the case -- it looks like each older version has 3-5 newer versions defined. If submitting the 7.18 sitemap with 7.18 canonicals escapes us from our current situation of Google having many old canonicals, then I don't think we care to go back and add all version definitions to all old versions; on the other hand, if submitting the 7.18 sitemap with 7.18 canonicals only frees a portion of URLs from Google's old canonicals, we'll have to figure out which old versions we want to retro-fix. 

I will likely apply this to 7.18 before merging into the theme, to make sure it works, before propagating to other versions.

## Proof that it will generate a 7.18 URL in the sitemap for a version other than 7.18

<img width="1134" alt="image" src="https://user-images.githubusercontent.com/1627089/204921400-d18292e2-586e-40e1-b212-110319d85a49.png">

## Proof that it will generate a 7.18 URL in the page head for a version other than 7.18

<img width="1215" alt="image" src="https://user-images.githubusercontent.com/1627089/204921573-8083e404-d7ff-4b9d-aa69-f67af4f0a085.png">
