### PR TITLE
fix: prevent search results from being hidden at any resolution

### DIFF
--- a/styles/_search.less
+++ b/styles/_search.less
@@ -39,7 +39,8 @@
 .search-results {
   opacity: 0;
   position: fixed;
-  top: @header-height;
+  /* Prevents the search results from being hidden at any screen size, because our top nav height varies a lot. */
+  top: 123px;
   left: 5%;
   right: 5%;
   overflow: hidden;


### PR DESCRIPTION
Addresses #43.

In #41, we made the top nav taller, but didn't account for it on the search results modal. The first search result was being hidden by the top navigation.

This PR nudges the search results modal down a bit, so that it is not hidden at _any_ screen width.

Here is a video showing the search results modal at different widths, and proving that the search results modal will always be fully visible: 

https://github.com/camunda/camunda-docs-theme/assets/1627089/96336dd1-1034-4c05-8b99-ead0f01465ac




Note that there are no search results for BPMN because I'm running locally. The "no results" text appears roughly where the first search result would.


## Our top nav height varies a lot

I would have liked to use math based on the height of the top navigation to determine the exact `top` value, but the height of our top nav varies a lot. Not only due to intentional responsive styling, but also do to some overflow stacking, and at unintentional breakpoints. 

Here is a video that uses a color to indicate the responsive breakpoint, and it shows that the top bar height fluctuates at widths unrelated to the responsive breakpoints:

https://github.com/camunda/camunda-docs-theme/assets/1627089/0e0884f5-ce79-42b2-80a8-aec17844e0b9



Because this functionality is clearly not intentional (these breakpoints are not specified in the CSS), I do **not** intend on taking the time to find the exact breakpoints where the top bar height changes and using that to control how much the search result modal is nudged.

## The search box disappears at smaller widths

I'm not sure if this is intentional or not, but on mobile devices it seems like users probably can't even pull up the search results modal _anyway_. So the visibility/non-visibility of the search results doesn't really matter much at those smaller widths. Again, this isn't something I consider in scope for this PR or issue.

Fixing this issue for larger widths where it _does_ matter also fixed it for the smaller widths, and that is why they are included in the demo videos in this PR.

## Follow-up work

- Update theme in camunda-docs-manual
- Update theme in camunda-docs-static