### PR TITLE
fix: send search-results to back when it's not displaying

### DIFF
--- a/styles/_search.less
+++ b/styles/_search.less
@@ -44,7 +44,7 @@
   left: 5%;
   right: 5%;
   overflow: hidden;
-  z-index: 7;
+  z-index: 0;
 
   transform: translateY(0 - (@grid-gutter-width * 2));
   transition: transform 0.218s ease, opacity 0.218s ease;
@@ -138,6 +138,7 @@ body.search-open {
   .search-results {
     opacity: 1;
     transform: translateY(0);
+    z-index: 7;
     ul {
       max-height: 500px;
     }


### PR DESCRIPTION
In #44, I nudged the search results window further down on the screen, so that it wasn't masked by the top navigation. Unfortunately, this resulted in the social links at the top not being clickable, because _they_ are now masked by the search results window, which has a relatively high `z-index` even when it's not displaying.

This PR sets the `z-index` of the search-results window to 0 when it is not displaying, and `7` when it is displaying. I chose `7` because that's what it was previously always set to 🤷.

## Proof that the social links are not masked by the hidden search-results element


https://github.com/camunda/camunda-docs-theme/assets/1627089/4a7e93bc-1611-44bd-96b2-86623fa41aca

## Follow-up tasks

Update the theme & deploy to prod for:
- camunda-docs-manual/`master`
- camunda-docs-manual/`latest`
- camunda-docs-manual/`7.20`
- camunda-docs-static/`master`/get-started
- camunda-docs-static/`master`/enterprise
- camunda-docs-static/`master`/security